### PR TITLE
Include GNU readline to improve raw_input prompt

### DIFF
--- a/src/lamby.py
+++ b/src/lamby.py
@@ -4,6 +4,9 @@
 
 import sys
 
+# import GNU readline library to greatly improve raw_input() prompt
+import readline
+
 # directions from PLY package
 import ply.lex as lex
 import ply.yacc as yacc


### PR DESCRIPTION
Python's built-in raw_input() isn't meant for a full REPL, but instead just to capture values. As a result, it doesn't have support for any types of keybinds (C-a, C-e, M-left, etc.) or even arrow key usage. Simply importing readline will tell Python to turn the prompt into a fully featured GNU readline instance.